### PR TITLE
feat(etcd-backup): simplify Dockerfile and fix CJ/backup script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8-minimal:8.8-1072.1696517598
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9-1029
 
 LABEL org.opencontainers.image.authors="Adfinis AG <https://adfinis.com>"
 LABEL org.opencontainers.image.vendor="Adfinis"
@@ -6,9 +6,7 @@ LABEL org.opencontainers.image.vendor="Adfinis"
 COPY backup.sh /usr/local/bin/backup.sh
 
 RUN microdnf update -y && rm -rf /var/cache/yum
-RUN microdnf install findutils wget tar gzip -y && microdnf clean all
-RUN wget https://github.com/etcd-io/etcd/releases/download/v3.4.27/etcd-v3.4.27-linux-amd64.tar.gz -O /tmp/etcd-v3.4.27-linux-amd64.tar.gz
-RUN tar -xvf /tmp/etcd-v3.4.27-linux-amd64.tar.gz -C /tmp/ && mv /tmp/etcd-v3.4.27-linux-amd64/etcdctl /usr/local/bin/etcdctl && rm -rf /tmp/etcd-v3.4.27-linux-amd64*
-
+RUN microdnf install findutils curl tar gzip -y && microdnf clean all
+RUN curl -L https://github.com/etcd-io/etcd/releases/download/v3.5.11/etcd-v3.5.11-linux-amd64.tar.gz | tar xfz - -C /tmp --strip-components=1 --no-same-owner -- etcd-v3.5.11-linux-amd64/etcdctl
 
 CMD ["/usr/local/bin/backup.sh"]

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ If you run etcd outside of your cluster, you can get the information from the et
 Get the certificates from the Kubernetes host and put them into a secret:
 ```
 kubectl create secret generic etcd-peer-tls --from-file=tls.crt --from-file=tls.key -n etcd-backup
-kubectl create secret generic etcd-server-ca --from-file=service-ca.crt -n etcd-backup
+kubectl create secret generic etcd-server-ca --from-file=ca.crt -n etcd-backup
 ```
 
 Add the endpoint IP address to the [ConfigMap](./backup-config.yaml), without scheme or port:

--- a/backup-cronjob.yaml
+++ b/backup-cronjob.yaml
@@ -15,9 +15,9 @@ spec:
           - command:
             - /bin/sh
             - /usr/local/bin/backup.sh
-            image: ghcr.io/xelef2000/general-etcd-backup:main
+            image: ghcr.io/adfinis/kubernetes-etcd-backup:main
             imagePullPolicy: Always
-            name: backup-etcd
+            name: etcd-backup
             resources:
               requests:
                 cpu: 500m
@@ -28,9 +28,6 @@ spec:
             envFrom:
             - configMapRef:
                 name: backup-config
-            # securityContext:
-              # privileged: true
-              # runAsUser: 0
             volumeMounts:
             - name: volume-backup
               mountPath: /backup
@@ -38,16 +35,7 @@ spec:
               mountPath: /etc/kubernetes/pki/etcd-peer
             - name: etcd-server-ca
               mountPath: /etc/kubernetes/pki/etcd-ca
-          # nodeSelector:
-            # node-role.kubernetes.io/master: ""
-          # tolerations:
-            # - effect: NoSchedule
-              # key: node-role.kubernetes.io/master
-          # hostNetwork: true
-          # hostPID: true
-          # serviceAccountName: etcd-backup
           restartPolicy: Never
-          # dnsPolicy: ClusterFirst
           volumes:
           - name: volume-backup
             persistentVolumeClaim:

--- a/backup.sh
+++ b/backup.sh
@@ -27,6 +27,7 @@
 # Authors:
 #  Cyrill von Wattenwyl <cyrill.vonwattenwyl@adfinis.com>
 #  Felix Niederer <felix.niederer@adfinis.com>
+#  Valentin Maillot <valentin.maillot@adfinis.com>
 
 
 set -xeuo pipefail
@@ -64,7 +65,7 @@ mkdir -p "/tmp/etcd-backup"
 mkdir -p "${BACKUP_PATH_POD}"
 
 # create backup to temporary location
-ETCDCTL_API=3 etcdctl --endpoints ${ENDPOINT}:2379 --cacert='/etc/kubernetes/pki/etcd-ca/service-ca.crt'  --cert='/etc/kubernetes/pki/etcd-peer/tls.crt' --key='/etc/kubernetes/pki/etcd-peer/tls.key' snapshot save /tmp/etcd-backup/snapshot.db 
+ETCDCTL_API=3 etcdctl --endpoints ${ENDPOINT}:2379 --cacert='/etc/kubernetes/pki/etcd-ca/ca.crt'  --cert='/etc/kubernetes/pki/etcd-peer/tls.crt' --key='/etc/kubernetes/pki/etcd-peer/tls.key' snapshot save /tmp/etcd-backup/snapshot.db
 ETCDCTL_API=3 etcdctl --write-out=table snapshot status /tmp/etcd-backup/snapshot.db
 
 # move files to pvc and delete temporary files


### PR DESCRIPTION
Signed-off-by: Valentin Maillot <valentin.maillot@adfinis.com>

* update ubi8 image to latest
* remove complexicity in `Dockerfile`
* adjust CA file name in `backup.sh`
* update `CronJob` container name and image
* remove comments
