### PR TITLE
chore(dependebot): change prefix for container images updates to fix

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -7,7 +7,7 @@ updates:
     schedule:
       interval: "daily"
     commit-message:
-      prefix: "feat: "
+      prefix: "fix: "
 
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
Since the container image updates are primarily security updates it makes no sense to increase the minor version for those.