### PR TITLE
fix: refactor Dockerfile and update base os and dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,31 +1,27 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10-1179.1741863533
+FROM registry.access.redhat.com/ubi9-minimal:9.5
 
 LABEL org.opencontainers.image.authors="Adfinis AG <https://adfinis.com>"
 LABEL org.opencontainers.image.vendor="Adfinis"
 
-COPY backup.sh /usr/local/bin/backup.sh
-
-RUN microdnf update -y && rm -rf /var/cache/yum
+ENV MC_CONFIG_DIR=/opt/mc/config
 
 # hadolint ignore=DL3041
-RUN microdnf install -y curl findutils gzip tar \
-    && microdnf clean all
-
-RUN curl -O https://dl.min.io/client/mc/release/linux-amd64/mc.rpm \
+RUN microdnf update -y \
+    && microdnf install -y findutils gzip tar \
+    && microdnf clean all \
+    && curl -O https://dl.min.io/client/mc/release/linux-amd64/mc.rpm \
     && rpm -ih mc.rpm \
-    && rm mc.rpm
-    
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN /bin/bash -o pipefail -c "\
-    curl -L https://github.com/etcd-io/etcd/releases/download/v3.5.15/etcd-v3.5.15-linux-amd64.tar.gz \
-    | tar xfz - -C /tmp --strip-components=1 --no-same-owner -- etcd-v3.5.15-linux-amd64/ \
-    && mv /tmp/etcdctl /usr/local/bin/ \
-    && mv /tmp/etcdutl /usr/local/bin/ \
-    && mv /tmp/etcd /usr/local/bin/ \
-    "
+    && rm mc.rpm \
+    && curl -o /tmp/etcd.tgz -L https://github.com/etcd-io/etcd/releases/download/v3.5.21/etcd-v3.5.21-linux-amd64.tar.gz \
+    && mkdir /tmp/etcd \
+    && tar xfz /tmp/etcd.tgz -C /tmp/etcd --strip-components=1 --no-same-owner \
+    && mv /tmp/etcd/etcdctl /usr/local/bin/ \
+    && mv /tmp/etcd/etcdutl /usr/local/bin/ \
+    && mv /tmp/etcd/etcd /usr/local/bin/ \
+    && rm -rf /tmp/etcd/ /tmp/etcd.tgz \
+    && mkdir -p $MC_CONFIG_DIR \
+    && chown 1000:1000 $MC_CONFIG_DIR
 
-ENV MC_CONFIG_DIR=/opt/mc/config
-RUN mkdir -p $MC_CONFIG_DIR && \
-    chown 1000:1000 $MC_CONFIG_DIR
+COPY backup.sh /usr/local/bin/backup.sh
 
 CMD ["/usr/local/bin/backup.sh"]


### PR DESCRIPTION
* refactor the Dockerfile to not use docker specific instructions like `SHELL`
* merge all layers into a single layer
* remove leftovers from etcd installation in /tmp
* use available curl instead of attempting to replace it with a different package (we have curl-minimal and it works for our purpose)